### PR TITLE
setCapabilityValue boolean fix & constant warning

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Homeyduino
-version=1.0.1
+version=1.0.2
 author=Athom B.V.
 maintainer=Athom B.V. <renze@athom.nl>
 sentence=Homeyduino allows you to connect your Arduino projects with Homey.

--- a/src/Homey.cpp
+++ b/src/Homey.cpp
@@ -135,14 +135,14 @@ bool HomeyClass::trigger(const String& name, bool value)
 	return _emit(name.c_str(), CTYPE_BOOL, str, TYPE_TRIGGER);
 }
 
-bool HomeyClass::setCapabilityValue(const String& name, bool emit)
+/*bool HomeyClass::setCapabilityValue(const String& name, bool emit)
 {
 	if (!emit) {
 		_setValue(name.c_str(), CTYPE_NULL, "null", TYPE_CAPABILITY);
 		return true;
 	}
 	return _emit(name.c_str(), CTYPE_NULL, "null", TYPE_CAPABILITY);
-}
+}*/
 bool HomeyClass::setCapabilityValue(const String& name, const char* value, bool emit)
 {
 	if (!emit) {
@@ -682,7 +682,7 @@ void HomeyClass::streamWriteIndex(Stream* s) {
 	s->print('"');
 
 	//Version
-	s->print(",\"version\":\""HOMEYDUINO_VERSION"\"");
+	s->print(",\"version\":\"" HOMEYDUINO_VERSION "\"");
 
 	//Type field
 	s->print(",\"type\":\"");

--- a/src/Homey.h
+++ b/src/Homey.h
@@ -17,7 +17,7 @@
 /* -------------- DO NOT EDIT ANYTHING BELOW THIS LINE!  -------------- */
 /* (If you do you might break compatibility with the Homeyduino app...) */
 
-#define HOMEYDUINO_VERSION "1.0.1"
+#define HOMEYDUINO_VERSION "1.0.2"
 
 #define ENDPOINT_MAX_SIZE 17 //16 + null
 #define ARGUMENT_MAX_SIZE 65 //64 + null


### PR DESCRIPTION
This release fixes a bug that caused compiling to fail when setCapabiltyValue
is used with value type boolean.

Also fixes a compiler warning about the version constant in the descriptor.