### PR TITLE
Add support for Arduino MKR WiFi 1010 and MKR 1000

### DIFF
--- a/src/Homey.cpp
+++ b/src/Homey.cpp
@@ -246,7 +246,7 @@ void HomeyClass::returnNothing()
 void HomeyClass::returnError(const String& error, uint16_t code)
 {
 	_response.code = code;
-	_response.response  = '\"';
+	_response.response  = "\"";
 	_response.response += error;
 	_response.response += '\"';
 	_response.type = "err";

--- a/src/Homey.h
+++ b/src/Homey.h
@@ -69,6 +69,13 @@
 	#define TCP_SERVER_TYPE WiFiServer
 	#define UDP_TX_PACKET_MAX_SIZE 1024
 	#define MAXCALLBACKS 10
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_MKRWIFI1000)
+	#include <WiFiNINA.h>
+	#define CLIENT_TYPE WiFiClient
+	#define UDP_SERVER_TYPE WiFiUDP
+	#define TCP_SERVER_TYPE WiFiServer
+	#define MAXCALLBACKS 10
+	#define CAN_NOT_STOP_TCP
 #elif defined(HOMEY_USE_ETHERNET_V1)
 	#include <Ethernet.h>
 	#include <EthernetUdp.h>


### PR DESCRIPTION
This PR adds support for Arduino MKR WiFi 1010 and MKR 1000 boards, which use the WiFiNINA library.
Problem
The Homeyduino library currently doesn't recognize MKR WiFi boards and falls back to Ethernet2, causing compilation errors:

> fatal error: Ethernet2.h: No such file or directory

Additionally, when compiling for SAMD boards with newer Arduino cores, a String assignment error occurs:

> error: ambiguous overload for 'operator=' (operand types are 'arduino::String' and 'char')

**Solution**

Added board detection for ARDUINO_SAMD_MKRWIFI1010 and ARDUINO_SAMD_MKRWIFI1000 in Homey.h
Fixed char-to-String assignment in Homey.cpp for SAMD core compatibility

**Tested on**

Arduino MKR WiFi 1010
Homey Pro (Early 2023)
Arduino IDE 2.3.6
Arduino SAMD core 1.8.14